### PR TITLE
mvvmを適用

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/SearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/SearchFragment.kt
@@ -18,6 +18,7 @@ import androidx.recyclerview.widget.*
 import jp.co.yumemi.android.code_check.databinding.FragmentSearchBinding
 import jp.co.yumemi.android.code_check.util.withCatch
 import jp.co.yumemi.android.code_check.model.RepositoryItem
+import jp.co.yumemi.android.code_check.viewmodel.DetailViewModel
 
 /**
  * レポジトリ検索ページ

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/view/RepositoryDetailFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/view/RepositoryDetailFragment.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2021 YUMEMI Inc. All rights reserved.
  */
-package jp.co.yumemi.android.code_check
+package jp.co.yumemi.android.code_check.view
 
 import android.os.Bundle
 import android.util.Log
@@ -10,9 +10,10 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import coil.load
 import jp.co.yumemi.android.code_check.MainActivity.Companion.lastSearchDate
+import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.databinding.FragmentRepositoryDetailBinding
-import jp.co.yumemi.android.code_check.util.withCatch
 import jp.co.yumemi.android.code_check.model.RepositoryItem
+import jp.co.yumemi.android.code_check.util.withCatch
 
 class RepositoryDetailFragment : Fragment(R.layout.fragment_repository_detail) {
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/view/SearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/view/SearchFragment.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2021 YUMEMI Inc. All rights reserved.
  */
-package jp.co.yumemi.android.code_check
+package jp.co.yumemi.android.code_check.view
 
 import android.content.Context
 import android.os.Bundle
@@ -15,9 +15,10 @@ import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.*
+import jp.co.yumemi.android.code_check.R
 import jp.co.yumemi.android.code_check.databinding.FragmentSearchBinding
-import jp.co.yumemi.android.code_check.util.withCatch
 import jp.co.yumemi.android.code_check.model.RepositoryItem
+import jp.co.yumemi.android.code_check.util.withCatch
 import jp.co.yumemi.android.code_check.viewmodel.DetailViewModel
 
 /**

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewmodel/SearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/viewmodel/SearchViewModel.kt
@@ -1,7 +1,7 @@
 /*
  * Copyright © 2021 YUMEMI Inc. All rights reserved.
  */
-package jp.co.yumemi.android.code_check
+package jp.co.yumemi.android.code_check.viewmodel
 
 import androidx.lifecycle.ViewModel
 import jp.co.yumemi.android.code_check.model.RepositoryItem

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -7,7 +7,7 @@
 
     <fragment
         android:id="@+id/listFragment"
-        android:name="jp.co.yumemi.android.code_check.SearchFragment"
+        android:name="jp.co.yumemi.android.code_check.view.SearchFragment"
         android:label="@string/app_name"
         tools:layout="@layout/fragment_search">
         <action
@@ -17,12 +17,12 @@
 
     <fragment
         android:id="@+id/detailFragment"
-        android:name="jp.co.yumemi.android.code_check.RepositoryDetailFragment"
+        android:name="jp.co.yumemi.android.code_check.view.RepositoryDetailFragment"
         android:label="@string/app_name"
         tools:layout="@layout/fragment_repository_detail">
         <argument
             android:name="item"
-            app:argType="jp.co.yumemi.android.code_check.viewmodel.RepositoryItem" />
+            app:argType="jp.co.yumemi.android.code_check.model.RepositoryItem" />
     </fragment>
 
 </navigation>


### PR DESCRIPTION
以下issueのコメントにもあるとおりMVVMモデルを適用。
具体的には以下フォルダにUIと検索のロジック・検索の実装を切り出した。

- view ... UI
- model ... 検索の実装
- viewmodel ... 検索のロジック

例えば将来検索先をGithub以外からも探したいといった要件ではmodel部分に修正を加えれば良い。

https://github.com/TBSten/yumemi-android-engineer-codecheck/issues/6#issuecomment-1173834149
